### PR TITLE
elastalert error for default operator

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -256,9 +256,11 @@ class RulesLoader(object):
             #Setting default operator for filters as AND as in elastalert-0.1.35
             if 'filter' in loaded:
                 for filter in loaded['filter']:
-                    if 'query' in filter:
-                        if 'query_string' in filter['query']: 
+                    if 'query' in filter and filter['query'] != None:
+                        if 'query_string' in filter['query'] and filter['query']['query_string']!= None: 
                             filter['query']['query_string']['default_operator'] = "AND"
+                    else:
+                        elastalert_logger.info("Query is None in file: %s",filename)
 
             # Special case for merging filters - if both files specify a filter merge (AND) them
             if 'filter' in rule and 'filter' in loaded:


### PR DESCRIPTION
## Description

Fix erroring out elastalert image when query is None

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
