### PR TITLE
[HAYS-4738] fix response and query for percentile query

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1192,9 +1192,9 @@ class MetricAggregationRule(BaseAggregationRule):
     def crossed_thresholds(self, metric_value):
         if metric_value is None:
             return False
-        if 'max_threshold' in self.rules and int(metric_value) > self.rules['max_threshold']:
+        if 'max_threshold' in self.rules and float(metric_value) > self.rules['max_threshold']:
             return True
-        if 'min_threshold' in self.rules and int(metric_value) < self.rules['min_threshold']:
+        if 'min_threshold' in self.rules and float(metric_value) < self.rules['min_threshold']:
             return True
         return False
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1134,6 +1134,7 @@ class MetricAggregationRule(BaseAggregationRule):
         query = {self.metric_key: {self.rules['metric_agg_type']: {'field': self.rules['metric_agg_key']}}}
         if self.rules['metric_agg_type'] in self.allowed_percent_aggregations:
             query[self.metric_key][self.rules['metric_agg_type']]['percents'] = [self.rules['percentile_range']]
+            query[self.metric_key][self.rules['metric_agg_type']]['keyed'] = False
         return query
 
     def check_matches(self, timestamp, query_key, aggregation_data):
@@ -1143,7 +1144,8 @@ class MetricAggregationRule(BaseAggregationRule):
         else:
             if self.rules['metric_agg_type'] in self.allowed_percent_aggregations:
                 #backwards compatibility with existing elasticsearch library
-                metric_val = list(aggregation_data[self.metric_key]['values'][0].values())[0]
+                #aggregation_data = {"doc_count":258757,"key":"appmailer","metric_qt_percentiles":{"values":[{"key":95,"value":0}]}}
+                metric_val = aggregation_data[self.metric_key]['values'][0]['value']
             else:
                 metric_val = aggregation_data[self.metric_key]['value']
             if self.crossed_thresholds(metric_val):


### PR DESCRIPTION
## Description
Elastalert when querying for percentile metric aggregation, it is failing to parse the response. 
Added keyed: false as to how it is getting passed in OSD.
Parsing response appropriately.

https://freshworks.freshrelease.com/ws/HAYS/tasks/HAYS-4738

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
