### PR TITLE
[HAYS-4782]query_delay support in conf added

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -92,6 +92,8 @@ def load_conf(args, defaults=None, overrides=None):
             conf['old_query_limit'] = datetime.timedelta(**conf['old_query_limit'])
         else:
             conf['old_query_limit'] = datetime.timedelta(weeks=1)
+        if 'query_delay' in conf:
+            conf['query_delay'] = datetime.timedelta(**conf['query_delay'])
     except (KeyError, TypeError) as e:
         raise EAException('Invalid time format used: %s' % e)
 


### PR DESCRIPTION
Most of the times there is a little bit lag in logs ingestion. Due to this lag, there is a chance of missing log alerts. To overcame this, elastalert provided a parameter query_delay which will run the rules with a delay such that chance of missing log alerts will be decreased.
In order to add the query_delay parameter to elastalert configuration, we need to convert that query_delay value to datetime object. For that, we need to add a condition on query_delay parameter in elastalert config.py file.