### PR TITLE
[HAYS-5029] include using use_count_query

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -453,7 +453,6 @@ class ElastAlerter(object):
             elastalert_logger.info(status_log)
 
         hits = self.process_hits(rule, hits)
-
         return hits
 
     
@@ -504,8 +503,9 @@ class ElastAlerter(object):
             starttime,
             endtime,
             timestamp_field=rule['timestamp_field'],
-            sort=False,
+            sort=True,
             to_ts_func=rule['dt_to_ts'],
+            desc=True,
         )
 
         request = get_msearch_query(query,rule)
@@ -528,7 +528,14 @@ class ElastAlerter(object):
             "Queried rule %s from %s to %s: %s hits" % (rule['name'], pretty_ts(starttime, lt, self.pretty_ts_format),
                                                         pretty_ts(endtime, lt, self.pretty_ts_format), res['hits']['total'])
         )
-        return {endtime: res['hits']['total']}
+        
+        if len(res['hits']['hits']) > 0 :
+            event = self.process_hits(rule, res['hits']['hits'])
+        else:
+            event= self.process_hits(rule,[{'_source': {'@timestamp': endtime}}])
+            
+        return {"endtime":endtime,"count": res['hits']['total'],"event": event}
+        #return {endtime: res['hits']['total']}
 
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
         rule_filter = copy.copy(rule['filter'])
@@ -727,7 +734,6 @@ class ElastAlerter(object):
             elastalert_logger.info("Query start and end time converting UTC to query_timezone : {}".format(rule.get('query_timezone')))
             start = ts_utc_to_tz(start, rule.get('query_timezone'))
             end = ts_utc_to_tz(end, rule.get('query_timezone'))
-
         # Reset hit counter and query
         rule_inst = rule['type']
         rule['scrolling_cycle'] = rule.get('scrolling_cycle', 0) + 1
@@ -988,7 +994,6 @@ class ElastAlerter(object):
 
         rule['original_starttime'] = rule['starttime']
         rule['scrolling_cycle'] = 0
-
         self.thread_data.num_hits = 0
         self.thread_data.num_dupes = 0
         self.thread_data.cumulative_hits = 0
@@ -1978,7 +1983,7 @@ class ElastAlerter(object):
             index = self.get_index(rule, starttime, endtime)
 
             hits_terms = self.get_hits_terms(rule, starttime, endtime, index, key, qk, number)
-            if hits_terms is None:
+            if hits_terms is None or not hits_terms:
                 top_events_count = {}
             else:
                 buckets = list(hits_terms.values())[0]

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -225,6 +225,8 @@ class FrequencyRule(RuleType):
     #     self.check_for_match('all')
 
     def add_count_data(self, data):
+        # data struncture should be -> data: {endtime:<dateTime>,count:<CountOfEvents>,event:[{}]}
+        # if data doesn't have endtime and count as above example, raise an exception
         if not 'endtime' in data or not 'count' in data:
             raise EAException('add_count_data should have endtime and count')
         ts = data['endtime']
@@ -552,6 +554,9 @@ class SpikeRule(RuleType):
         #     raise EAException('add_count_data can only accept one count at a time')
         # for ts, count in data.items():
         #     self.handle_event({self.ts_field: ts}, count, 'all')
+
+        # data struncture should be -> data: {endtime:<dateTime>,count:<CountOfEvents>,event:[{}]}
+        # if data doesn't have endtime and count as above example, raise an exception
         ts = data['endtime']
         count = data['count']
         self.handle_event({self.ts_field: ts}, count, 'all')     

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -26,7 +26,7 @@ def get_msearch_query(query, rule):
     search_arr = []
     search_arr.append({'index': [rule['index']]})
     if rule.get('use_count_query'):
-        query['size'] = 0
+        query['size'] = 1
     if rule.get('include'):
         query['_source'] = {}
         query['_source']['includes'] = rule['include']

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -115,26 +115,26 @@ def test_freq_count():
              'use_count_query': True}
     # Normal match
     rule = FrequencyRule(rules)
-    rule.add_count_data({ts_to_dt('2014-10-10T00:00:00'): 75})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T00:00:00')}],'endtime':ts_to_dt('2014-10-10T00:00:00'),'count': 75})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-10T00:15:00'): 10})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T00:15:00')}],'endtime':ts_to_dt('2014-10-10T00:15:00'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-10T00:25:00'): 10})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T00:25:00')}],'endtime':ts_to_dt('2014-10-10T00:25:00'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-10T00:45:00'): 6})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T00:45:00')}],'endtime':ts_to_dt('2014-10-10T00:45:00'),'count': 6})
     assert len(rule.matches) == 1
 
     # First data goes out of timeframe first
     rule = FrequencyRule(rules)
-    rule.add_count_data({ts_to_dt('2014-10-10T00:00:00'): 75})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T00:00:00')}],'endtime':ts_to_dt('2014-10-10T00:00:00'),'count': 75})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-10T00:45:00'): 10})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T00:45:00')}],'endtime':ts_to_dt('2014-10-10T00:45:00'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-10T00:55:00'): 10})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T00:55:00')}],'endtime':ts_to_dt('2014-10-10T00:55:00'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-10T01:05:00'): 6})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T01:05:00')}],'endtime':ts_to_dt('2014-10-10T01:05:00'),'count': 6})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-10T01:00:00'): 75})
+    rule.add_count_data({'event':[{'@timestamp': ts_to_dt('2014-10-10T01:00:00')}],'endtime':ts_to_dt('2014-10-10T01:00:00'),'count': 75})
     assert len(rule.matches) == 1
 
     # except EAException
@@ -142,7 +142,7 @@ def test_freq_count():
         rule = FrequencyRule(rules)
         rule.add_count_data('aaaa')
     except EAException as ea:
-        assert 'add_count_data can only accept one count at a time' in str(ea)
+        assert 'add_count_data should have endtime and count' in str(ea)
 
 
 def test_freq_out_of_order():
@@ -226,20 +226,20 @@ def test_spike_count():
     rule = SpikeRule(rules)
 
     # Double rate of events at 20 seconds
-    rule.add_count_data({ts_to_dt('2014-09-26T00:00:00'): 10})
+    rule.add_count_data({'endtime':ts_to_dt('2014-09-26T00:00:00'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-09-26T00:00:10'): 10})
+    rule.add_count_data({'endtime':ts_to_dt('2014-09-26T00:00:10'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-09-26T00:00:20'): 20})
+    rule.add_count_data({'endtime':ts_to_dt('2014-09-26T00:00:20'),'count': 20})
     assert len(rule.matches) == 1
 
     # Downward spike
     rule = SpikeRule(rules)
-    rule.add_count_data({ts_to_dt('2014-09-26T00:00:00'): 10})
+    rule.add_count_data({'endtime':ts_to_dt('2014-09-26T00:00:00'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-09-26T00:00:10'): 10})
+    rule.add_count_data({'endtime':ts_to_dt('2014-09-26T00:00:10'),'count': 10})
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-09-26T00:00:20'): 0})
+    rule.add_count_data({'endtime':ts_to_dt('2014-09-26T00:00:20'),'count': 0})
     assert len(rule.matches) == 1
 
 
@@ -1106,13 +1106,13 @@ def test_flatline_count():
              'threshold': 1,
              'timestamp_field': '@timestamp'}
     rule = FlatlineRule(rules)
-    rule.add_count_data({ts_to_dt('2014-10-11T00:00:00'): 1})
+    rule.add_count_data({'endtime':ts_to_dt('2014-10-11T00:00:00'),'count': 1})
     rule.garbage_collect(ts_to_dt('2014-10-11T00:00:10'))
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-11T00:00:15'): 0})
+    rule.add_count_data({'endtime':ts_to_dt('2014-10-11T00:00:15'),'count': 0})
     rule.garbage_collect(ts_to_dt('2014-10-11T00:00:20'))
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-11T00:00:35'): 0})
+    rule.add_count_data({'endtime':ts_to_dt('2014-10-11T00:00:35'),'count': 0})
     assert len(rule.matches) == 1
 
 


### PR DESCRIPTION
## Description

HAYS-5029

Currently in our elastalert, when we made use_count_query mandatory, users are not able to get message and other text fields in top count keys.
So inorder to support the breaking change, we will add include param in rule instead of top_count_keys when message field is encountered, so that these fields info can be obtained in the alert.
How we are going to do :
we will continue use_count_query and make custom changes so that elastalert will get 1 document while making the query. we will use this document and add include param fields in alert.


## Checklist
- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
