### PR TITLE
add alert_time as label in alert

### DIFF
--- a/elastalert/alerters/alertmanager.py
+++ b/elastalert/alerters/alertmanager.py
@@ -60,7 +60,7 @@ class AlertmanagerAlerter(Alerter):
         }
 
         if self.rule.get('timestamp_field') in matches[0]:
-            payload['labels']['alert_time']=matches[0][self.rule.get('timestamp_field')]
+            payload['labels']['alert_match_time']=matches[0][self.rule.get('timestamp_field')]
 
         for host in self.hosts:
             try:

--- a/elastalert/alerters/alertmanager.py
+++ b/elastalert/alerters/alertmanager.py
@@ -59,6 +59,9 @@ class AlertmanagerAlerter(Alerter):
             'labels': self.labels
         }
 
+        if self.rule.get('timestamp_field') in matches[0]:
+            payload['labels']['alert_time']=matches[0][self.rule.get('timestamp_field')]
+
         for host in self.hosts:
             try:
                 url = host


### PR DESCRIPTION
Add a label with alert time as a value, so that noc can use this value in calling reports visualization

## Checklist

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
