### PR TITLE
adding changes for adv query support in elastalert

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -637,7 +637,6 @@ class ElastAlerter(object):
             to_ts_func=rule['dt_to_ts'],
         )
         request = get_msearch_query(base_query,rule)
-        print("yoyo")
         try:
             #using backwards compatibile msearch
             res = self.thread_data.current_es.msearch(body=request)
@@ -775,7 +774,7 @@ class ElastAlerter(object):
         elif isinstance(rule_inst, ErrorRateRule):
             data = self.get_error_rate(rule, start, end)
         elif rule.get('aggregation_query_element'):
-            print("in agg query element")
+            elastalert_logger.info("in agg query element")
             if isinstance(rule_inst, AdvQueryRule):
                 data = self.get_adv_query_aggregation(rule, start, end,index,rule.get('query_key', None))
             else:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -626,7 +626,7 @@ class ElastAlerter(object):
         self.thread_data.num_hits += res['hits']['total']
         return {endtime: payload}
     
-    def get_adv_query_aggregation(self, rule, starttime, endtime, index, query_key, term_size=None):
+    def get_adv_query_aggregation(self, rule, starttime, endtime, index, term_size=None):
         rule_filter = copy.copy(rule['filter'])
         base_query = self.get_query(
             rule_filter,
@@ -776,7 +776,7 @@ class ElastAlerter(object):
         elif rule.get('aggregation_query_element'):
             elastalert_logger.info("in agg query element")
             if isinstance(rule_inst, AdvanceSearchRule):
-                data = self.get_adv_query_aggregation(rule, start, end,index,rule.get('query_key', None))
+                data = self.get_adv_query_aggregation(rule, start, end,index)
             else:
                 data = self.get_hits_aggregation(rule, start, end, index, rule.get('query_key', None))
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -29,6 +29,7 @@ from elasticsearch.exceptions import ConnectionError
 from elasticsearch.exceptions import ElasticsearchException
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.exceptions import TransportError
+from elastalert.ruletypes import AdvQueryRule
 from elastalert.ruletypes import ErrorRateRule, NewTermsRule
 from elastalert.ruletypes import PercentageMatchRule
 
@@ -624,6 +625,33 @@ class ElastAlerter(object):
 
         self.thread_data.num_hits += res['hits']['total']
         return {endtime: payload}
+    
+    def get_adv_query_aggregation(self, rule, starttime, endtime, index, query_key, term_size=None):
+        rule_filter = copy.copy(rule['filter'])
+        base_query = self.get_query(
+            rule_filter,
+            starttime,
+            endtime,
+            timestamp_field=rule['timestamp_field'],
+            sort=False,
+            to_ts_func=rule['dt_to_ts'],
+        )
+        request = get_msearch_query(base_query,rule)
+        print("yoyo")
+        try:
+            #using backwards compatibile msearch
+            res = self.thread_data.current_es.msearch(body=request)
+            res = res['responses'][0]
+        except ElasticsearchException as e:
+            if len(str(e)) > 1024:
+                e = str(e)[:1024] + '... (%d characters removed)' % (len(str(e)) - 1024)
+            self.handle_error('Error running query: %s' % (e), {'rule': rule['name']})
+            return None
+        if 'aggregations' not in res:
+            return {}
+        payload = res['aggregations']
+        self.thread_data.num_hits += res['hits']['total']
+        return {endtime: payload}
 
 
     #trace_alert specific error rate method
@@ -689,7 +717,7 @@ class ElastAlerter(object):
         elastalert_logger.info("request data is %s" % json.dumps(data))
         # res = requests.post(self.query_endpoint, json=data)
         # return None, None
-
+    
     def remove_duplicate_events(self, data, rule):
         new_events = []
         for event in data:
@@ -747,7 +775,12 @@ class ElastAlerter(object):
         elif isinstance(rule_inst, ErrorRateRule):
             data = self.get_error_rate(rule, start, end)
         elif rule.get('aggregation_query_element'):
-            data = self.get_hits_aggregation(rule, start, end, index, rule.get('query_key', None))
+            print("in agg query element")
+            if isinstance(rule_inst, AdvQueryRule):
+                data = self.get_adv_query_aggregation(rule, start, end,index,rule.get('query_key', None))
+            else:
+                data = self.get_hits_aggregation(rule, start, end, index, rule.get('query_key', None))
+
         else:
             data = self.get_hits(rule, start, end, index, scroll)
             if data:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -29,7 +29,7 @@ from elasticsearch.exceptions import ConnectionError
 from elasticsearch.exceptions import ElasticsearchException
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.exceptions import TransportError
-from elastalert.ruletypes import AdvQueryRule
+from elastalert.ruletypes import AdvanceSearchRule
 from elastalert.ruletypes import ErrorRateRule, NewTermsRule
 from elastalert.ruletypes import PercentageMatchRule
 
@@ -775,7 +775,7 @@ class ElastAlerter(object):
             data = self.get_error_rate(rule, start, end)
         elif rule.get('aggregation_query_element'):
             elastalert_logger.info("in agg query element")
-            if isinstance(rule_inst, AdvQueryRule):
+            if isinstance(rule_inst, AdvanceSearchRule):
                 data = self.get_adv_query_aggregation(rule, start, end,index,rule.get('query_key', None))
             else:
                 data = self.get_hits_aggregation(rule, start, end, index, rule.get('query_key', None))

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -29,7 +29,7 @@ from elasticsearch.exceptions import ConnectionError
 from elasticsearch.exceptions import ElasticsearchException
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.exceptions import TransportError
-from elastalert.ruletypes import AdvanceSearchRule
+from elastalert.ruletypes import AdvancedQueryRule
 from elastalert.ruletypes import ErrorRateRule, NewTermsRule
 from elastalert.ruletypes import PercentageMatchRule
 
@@ -775,7 +775,7 @@ class ElastAlerter(object):
             data = self.get_error_rate(rule, start, end)
         elif rule.get('aggregation_query_element'):
             elastalert_logger.info("in agg query element")
-            if isinstance(rule_inst, AdvanceSearchRule):
+            if isinstance(rule_inst, AdvancedQueryRule):
                 data = self.get_adv_query_aggregation(rule, start, end,index)
             else:
                 data = self.get_hits_aggregation(rule, start, end, index, rule.get('query_key', None))

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -94,7 +94,7 @@ class RulesLoader(object):
         'percentage_match': ruletypes.PercentageMatchRule,
         'spike_aggregation': ruletypes.SpikeMetricAggregationRule,
         'error_rate': ruletypes.ErrorRateRule,  #Adding Error Rate Rule type
-        'adv_query': ruletypes.AdvQueryRule
+        'advance_search': ruletypes.AdvanceSearchRule
     }
 
     # Used to map names of alerts to their classes

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -94,7 +94,7 @@ class RulesLoader(object):
         'percentage_match': ruletypes.PercentageMatchRule,
         'spike_aggregation': ruletypes.SpikeMetricAggregationRule,
         'error_rate': ruletypes.ErrorRateRule,  #Adding Error Rate Rule type
-        'advance_search': ruletypes.AdvanceSearchRule
+        'advanced_query': ruletypes.AdvancedQueryRule
     }
 
     # Used to map names of alerts to their classes

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -93,7 +93,8 @@ class RulesLoader(object):
         'metric_aggregation': ruletypes.MetricAggregationRule,
         'percentage_match': ruletypes.PercentageMatchRule,
         'spike_aggregation': ruletypes.SpikeMetricAggregationRule,
-        'error_rate': ruletypes.ErrorRateRule  #Adding Error Rate Rule type
+        'error_rate': ruletypes.ErrorRateRule,  #Adding Error Rate Rule type
+        'adv_query': ruletypes.AdvQueryRule
     }
 
     # Used to map names of alerts to their classes

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -746,6 +746,10 @@ class AdvQueryRule(RuleType):
             if 'buckets' in value:
                 if len(value['buckets']) >=0 :
                     self.check_matches_recursive(key,value['buckets'],timestamp)
+            else:
+                if self.crossed_thresholds(value['value']):
+                    match={"key":key,"value":value['value']}
+                    self.add_match(match)
 
     def check_matches_recursive(self,data_key,data_value,timestamp,data_key_value=''):
         key = data_key

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -720,14 +720,14 @@ class SpikeRule(RuleType):
                 placeholder.update({self.rules['query_key']: qk})
             self.handle_event(placeholder, 0, qk)
 
-class AdvanceSearchRule(RuleType):
+class AdvancedQueryRule(RuleType):
     """ A rule that uses a query_string query to perform a advanced search like parsing, evaluating conditions, calculating aggs etc """
     required_options = frozenset(['alert_field'])
 
     def __init__(self, *args):
-        super(AdvanceSearchRule, self).__init__(*args)
+        super(AdvancedQueryRule, self).__init__(*args)
         if 'max_threshold' not in self.rules and 'min_threshold' not in self.rules:
-            raise EAException("AdvanceSearchRule must have one of either max_threshold or min_threshold")
+            raise EAException("AdvancedQueryRule must have one of either max_threshold or min_threshold")
         #self.query_string = self.rules.get('query_string')
         self.rules['aggregation_query_element'] = {"query": ""}
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -725,9 +725,9 @@ class AdvanceSearchRule(RuleType):
     required_options = frozenset(['alert_field'])
 
     def __init__(self, *args):
-        super(AdvQueryRule, self).__init__(*args)
+        super(AdvanceSearchRule, self).__init__(*args)
         if 'max_threshold' not in self.rules and 'min_threshold' not in self.rules:
-            raise EAException("AdvQueryRule must have one of either max_threshold or min_threshold")
+            raise EAException("AdvanceSearchRule must have one of either max_threshold or min_threshold")
         #self.query_string = self.rules.get('query_string')
         self.rules['aggregation_query_element'] = {"query": ""}
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -731,10 +731,6 @@ class AdvanceSearchRule(RuleType):
         #self.query_string = self.rules.get('query_string')
         self.rules['aggregation_query_element'] = {"query": ""}
 
-    def run_query(self):
-        # Implement the logic to run the query using the query_string
-        raise NotImplementedError()
-
     def add_aggregation_data(self, payload):
         for timestamp, payload_data in payload.items():
             self.check_matches(payload_data,timestamp)

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -220,10 +220,10 @@ oneOf:
       error_condition: {type: string}
       unique_column: {type: string}
 
-  - title: Advance Search
+  - title: Advanced Query
     required: [alert_field]
     properties:
-      type: {enum: [advance_search]}
+      type: {enum: [advanced_query]}
 
 
 properties:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -220,6 +220,12 @@ oneOf:
       error_condition: {type: string}
       unique_column: {type: string}
 
+  - title: Adv Query
+    required: []
+    properties:
+      type: {enum: [adv_query]}
+
+
 properties:
 
   # Common Settings

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -220,10 +220,10 @@ oneOf:
       error_condition: {type: string}
       unique_column: {type: string}
 
-  - title: Adv Query
-    required: []
+  - title: Advance Search
+    required: [alert_field]
     properties:
-      type: {enum: [adv_query]}
+      type: {enum: [advance_search]}
 
 
 properties:


### PR DESCRIPTION
## Description

This PR supports adv query in elastalert. The idea is to give the adv query which is provided directly in kibana using filter string of elastalert, and evaluate the final metric using thresholds.
Currently adv query has limited output data formats, of which aggregations are of our prime concern because, adv query in alerts needs some final metric calculation, which falls under aggregations output type of advance query.

This rule type now takes given query, evaluates the query for a buffer_time window and compares the evaluated output (field of comparison is to be given in alert definition) with thresholds and fires the alert.

Since most  of alerts here would be on some stat, MetricAggregation way of solving the problem is taken here 


## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
