### PR TITLE
converting qk to string to solve the numeric field issue while using hit_terms

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -541,6 +541,7 @@ class ElastAlerter(object):
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
         rule_filter = copy.copy(rule['filter'])
         if qk:
+            qk = str(qk)
             qk_list = qk.split(",")
             end = '.keyword'
 


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
